### PR TITLE
Fix TLB-04 | Untrusted Router Address Risk

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -41,6 +41,13 @@ contract Treasury is Ownable, ITreasury {
     }
 
     /// @inheritdoc ITreasury
+    function setDexRouter(address _dexRouter) external override onlyOwner {
+        require(_dexRouter != address(0), "invalid zero address");
+        require(_dexRouter != dexRouter, "dex router already set");
+        dexRouter = _dexRouter;
+    }
+
+    /// @inheritdoc ITreasury
     function takeServiceFee(
         address _paymentToken,
         uint256 _amount,

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -41,6 +41,13 @@ contract Treasury is Ownable, ITreasury {
     }
 
     /// @inheritdoc ITreasury
+    function setFevrToken(address _fevrToken) external onlyOwner {
+        require(_fevrToken != address(0), "zero fevr token address");
+        require(_fevrToken != fevrToken, "fevr token address already set");
+        fevrToken = _fevrToken;
+    }
+
+    /// @inheritdoc ITreasury
     function setDexRouter(address _dexRouter) external override onlyOwner {
         require(_dexRouter != address(0), "invalid zero address");
         require(_dexRouter != dexRouter, "dex router already set");

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -6,6 +6,10 @@ interface ITreasury {
     /// @dev Only owner can call this function.
     function setLendingMaster(address _lendingMaster) external;
 
+    /// @notice Set fevr token address.
+    /// @dev Only owner can call this function.
+    function setFevrToken(address _fevrToken) external;
+
     /// @notice Set DEX router address.
     /// @dev Only owner can call this function.
     function setDexRouter(address _dexRouter) external;

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -6,6 +6,10 @@ interface ITreasury {
     /// @dev Only owner can call this function.
     function setLendingMaster(address _lendingMaster) external;
 
+    /// @notice Set DEX router address.
+    /// @dev Only owner can call this function.
+    function setDexRouter(address _dexRouter) external;
+
     /// @notice Take service fee.
     /// @dev Only lendingMaster can call this function.
     function takeServiceFee(


### PR DESCRIPTION
This fix does not prevent the addition of a malicious dex router address. However, we can set a new dex router address in case a malicious or invalid dex router has been added.